### PR TITLE
Declaration of Compliance upload

### DIFF
--- a/ckanext/scheming/lib/uploader.py
+++ b/ckanext/scheming/lib/uploader.py
@@ -67,16 +67,40 @@ class OrganizationUploader(object):
         self.old_filepath = None
 
         # hack into this to upload NAP DOC
-        self.doc_url = ''
-        self.doc_clear = None
-        self.doc_file_field = None
-        self.doc_upload_field_storage = None
-        self.doc_filename = None
-        self.doc_filepath = None
-        self.doc_tmp_filepath = None
-        self.doc_upload_file = None
-        self.doc_old_filename = None
-        self.doc_old_filepath = None
+        # SSTP
+        self.sstp_doc_url = ''
+        self.sstp_doc_clear = None
+        self.sstp_doc_file_field = None
+        self.sstp_doc_upload_field_storage = None
+        self.sstp_doc_filename = None
+        self.sstp_doc_filepath = None
+        self.sstp_doc_tmp_filepath = None
+        self.sstp_doc_upload_file = None
+        self.sstp_doc_old_filename = None
+        self.sstp_doc_old_filepath = None
+        # SRTI
+        self.srti_doc_url = ''
+        self.srti_doc_clear = None
+        self.srti_doc_file_field = None
+        self.srti_doc_upload_field_storage = None
+        self.srti_doc_filename = None
+        self.srti_doc_filepath = None
+        self.srti_doc_tmp_filepath = None
+        self.srti_doc_upload_file = None
+        self.srti_doc_old_filename = None
+        self.srti_doc_old_filepath = None
+        # RTTI
+        self.rtti_doc_url = ''
+        self.rtti_doc_clear = None
+        self.rtti_doc_file_field = None
+        self.rtti_doc_upload_field_storage = None
+        self.rtti_doc_filename = None
+        self.rtti_doc_filepath = None
+        self.rtti_doc_tmp_filepath = None
+        self.rtti_doc_upload_file = None
+        self.rtti_doc_old_filename = None
+        self.rtti_doc_old_filepath = None
+        # end hack
 
     def update_data_dict(self, data_dict, url_field, file_field, clear_field):
         """ Manipulate data from the data_dict.  url_field is the name of the
@@ -95,28 +119,78 @@ class OrganizationUploader(object):
             return
 
         # hack into this to upload NAP DOC
-        if self.doc_old_filename:
-            self.doc_old_filepath = os.path.join(self.storage_path, data_dict.get('name'), self.doc_old_filename)
+        # SSTP
+        if self.sstp_doc_old_filename:
+            self.sstp_doc_old_filepath = os.path.join(self.storage_path, data_dict.get('name'), self.sstp_doc_old_filename)
 
-        self.doc_clear = data_dict.pop('clear_upload_doc', None)
-        self.doc_file_field = 'upload_doc'
-        self.doc_upload_field_storage = data_dict.pop(self.doc_file_field, None)
-        if isinstance(self.doc_upload_field_storage, (ALLOWED_UPLOAD_TYPES)):
-            self.doc_filename = self.doc_upload_field_storage.filename
-            self.doc_filename = munge.munge_filename(self.doc_filename)
+        self.sstp_doc_clear = data_dict.pop('sstp_clear_upload_doc', None)
+        self.sstp_doc_file_field = 'sstp_upload_doc'
+        self.sstp_doc_upload_field_storage = data_dict.pop(self.sstp_doc_file_field, None)
+        if isinstance(self.sstp_doc_upload_field_storage, (ALLOWED_UPLOAD_TYPES)):
+            self.sstp_doc_filename = self.sstp_doc_upload_field_storage.filename
+            self.sstp_doc_filename = munge.munge_filename(self.sstp_doc_filename)
             organization_storagepath = os.path.join(self.storage_path, data_dict.get('name'))
             _make_dirs_if_not_existing(organization_storagepath)
-            self.doc_filepath = os.path.join(organization_storagepath, self.doc_filename)
-            data_dict['doc_document_upload'] = self.doc_filename
+            self.sstp_doc_filepath = os.path.join(organization_storagepath, self.sstp_doc_filename)
+            data_dict['sstp_doc_document_upload'] = self.sstp_doc_filename
             data_dict['url_type'] = 'upload'
-            self.doc_upload_file = _get_underlying_file(self.doc_upload_field_storage)
-            self.doc_tmp_filepath = self.doc_filepath + '~'
+            self.sstp_doc_upload_file = _get_underlying_file(self.sstp_doc_upload_field_storage)
+            self.sstp_doc_tmp_filepath = self.sstp_doc_filepath + '~'
         # keep the file if there has been no change
-        elif self.doc_old_filename and not self.doc_old_filename.startswith('http'):
-            if not self.doc_clear:
-                data_dict['doc_document_upload'] = self.doc_old_filename
-            if self.doc_clear and self.doc_url == self.doc_old_filename:
-                data_dict['doc_document_upload'] = ''
+        elif self.sstp_doc_old_filename and not self.sstp_doc_old_filename.startswith('http'):
+            if not self.sstp_doc_clear:
+                data_dict['sstp_doc_document_upload'] = self.sstp_doc_old_filename
+            if self.sstp_doc_clear and self.sstp_doc_url == self.sstp_doc_old_filename:
+                data_dict['sstp_doc_document_upload'] = ''
+
+        # SRTI
+        if self.srti_doc_old_filename:
+            self.srti_doc_old_filepath = os.path.join(self.storage_path, data_dict.get('name'),
+                                                 self.srti_doc_old_filename)
+
+        self.srti_doc_clear = data_dict.pop('srti_clear_upload_doc', None)
+        self.srti_doc_file_field = 'srti_upload_doc'
+        self.srti_doc_upload_field_storage = data_dict.pop(self.srti_doc_file_field, None)
+        if isinstance(self.srti_doc_upload_field_storage, (ALLOWED_UPLOAD_TYPES)):
+            self.srti_doc_filename = self.srti_doc_upload_field_storage.filename
+            self.srti_doc_filename = munge.munge_filename(self.srti_doc_filename)
+            organization_storagepath = os.path.join(self.storage_path, data_dict.get('name'))
+            _make_dirs_if_not_existing(organization_storagepath)
+            self.srti_doc_filepath = os.path.join(organization_storagepath, self.srti_doc_filename)
+            data_dict['srti_doc_document_upload'] = self.srti_doc_filename
+            data_dict['url_type'] = 'upload'
+            self.srti_doc_upload_file = _get_underlying_file(self.srti_doc_upload_field_storage)
+            self.srti_doc_tmp_filepath = self.srti_doc_filepath + '~'
+        # keep the file if there has been no change
+        elif self.srti_doc_old_filename and not self.srti_doc_old_filename.startswith('http'):
+            if not self.srti_doc_clear:
+                data_dict['srti_doc_document_upload'] = self.srti_doc_old_filename
+            if self.srti_doc_clear and self.srti_doc_url == self.srti_doc_old_filename:
+                data_dict['srti_doc_document_upload'] = ''
+
+        # RTTI
+        if self.rtti_doc_old_filename:
+            self.rtti_doc_old_filepath = os.path.join(self.storage_path, data_dict.get('name'), self.rtti_doc_old_filename)
+
+        self.rtti_doc_clear = data_dict.pop('rtti_clear_upload_doc', None)
+        self.rtti_doc_file_field = 'rtti_upload_doc'
+        self.rtti_doc_upload_field_storage = data_dict.pop(self.rtti_doc_file_field, None)
+        if isinstance(self.rtti_doc_upload_field_storage, (ALLOWED_UPLOAD_TYPES)):
+            self.rtti_doc_filename = self.rtti_doc_upload_field_storage.filename
+            self.rtti_doc_filename = munge.munge_filename(self.rtti_doc_filename)
+            organization_storagepath = os.path.join(self.storage_path, data_dict.get('name'))
+            _make_dirs_if_not_existing(organization_storagepath)
+            self.rtti_doc_filepath = os.path.join(organization_storagepath, self.rtti_doc_filename)
+            data_dict['rtti_doc_document_upload'] = self.rtti_doc_filename
+            data_dict['url_type'] = 'upload'
+            self.rtti_doc_upload_file = _get_underlying_file(self.rtti_doc_upload_field_storage)
+            self.rtti_doc_tmp_filepath = self.rtti_doc_filepath + '~'
+        # keep the file if there has been no change
+        elif self.rtti_doc_old_filename and not self.rtti_doc_old_filename.startswith('http'):
+            if not self.rtti_doc_clear:
+                data_dict['rtti_doc_document_upload'] = self.rtti_doc_old_filename
+            if self.rtti_doc_clear and self.rtti_doc_url == self.rtti_doc_old_filename:
+                data_dict['rtti_doc_document_upload'] = ''
         # end NAP DOC hack
 
         if self.old_filename:
@@ -166,21 +240,63 @@ class OrganizationUploader(object):
                 pass
 
         # hack into this to upload NAP DOC
-        if self.doc_filename:
-            with open(self.doc_tmp_filepath, 'wb+') as output_file:
+        # SSTP
+        if self.sstp_doc_filename:
+            with open(self.sstp_doc_tmp_filepath, 'wb+') as output_file:
                 try:
-                    _copy_file(self.doc_upload_file, output_file, max_size)
+                    _copy_file(self.sstp_doc_upload_file, output_file, max_size)
                 except logic.ValidationError:
-                    os.remove(self.doc_tmp_filepath)
+                    os.remove(self.sstp_doc_tmp_filepath)
                     raise
                 finally:
-                    self.doc_upload_file.close()
-            os.rename(self.doc_tmp_filepath, self.doc_filepath)
-            self.doc_clear = True
+                    self.sstp_doc_upload_file.close()
+            os.rename(self.sstp_doc_tmp_filepath, self.sstp_doc_filepath)
+            self.sstp_doc_clear = True
 
-        if (self.doc_clear and self.doc_old_filename
-                and not self.doc_old_filename.startswith('http')):
+        if (self.sstp_doc_clear and self.sstp_doc_old_filename
+                and not self.sstp_doc_old_filename.startswith('http')):
             try:
-                os.remove(self.doc_old_filepath)
+                os.remove(self.sstp_doc_old_filepath)
             except OSError:
                 pass
+
+        # SRTI
+        if self.srti_doc_filename:
+            with open(self.srti_doc_tmp_filepath, 'wb+') as output_file:
+                try:
+                    _copy_file(self.srti_doc_upload_file, output_file, max_size)
+                except logic.ValidationError:
+                    os.remove(self.srti_doc_tmp_filepath)
+                    raise
+                finally:
+                    self.srti_doc_upload_file.close()
+            os.rename(self.srti_doc_tmp_filepath, self.srti_doc_filepath)
+            self.srti_doc_clear = True
+
+        if (self.srti_doc_clear and self.srti_doc_old_filename
+                and not self.srti_doc_old_filename.startswith('http')):
+            try:
+                os.remove(self.srti_doc_old_filepath)
+            except OSError:
+                pass
+
+        # RTTI
+        if self.rtti_doc_filename:
+            with open(self.rtti_doc_tmp_filepath, 'wb+') as output_file:
+                try:
+                    _copy_file(self.rtti_doc_upload_file, output_file, max_size)
+                except logic.ValidationError:
+                    os.remove(self.rtti_doc_tmp_filepath)
+                    raise
+                finally:
+                    self.rtti_doc_upload_file.close()
+            os.rename(self.rtti_doc_tmp_filepath, self.rtti_doc_filepath)
+            self.rtti_doc_clear = True
+
+        if (self.rtti_doc_clear and self.rtti_doc_old_filename
+                and not self.rtti_doc_old_filename.startswith('http')):
+            try:
+                os.remove(self.rtti_doc_old_filepath)
+            except OSError:
+                pass
+        # end hack

--- a/ckanext/scheming/lib/uploader.py
+++ b/ckanext/scheming/lib/uploader.py
@@ -79,6 +79,16 @@ class OrganizationUploader(object):
         self.file_field = file_field
         self.upload_field_storage = data_dict.pop(file_field, None)
 
+        print("#" * 25)
+        print(data_dict)
+        print("-" * 25)
+        print(url_field)
+        print(clear_field)
+        print(file_field)
+
+        print("-" * 25)
+        print("#" * 25)
+
         if not self.storage_path:
             return
 

--- a/ckanext/scheming/lib/uploader.py
+++ b/ckanext/scheming/lib/uploader.py
@@ -95,15 +95,12 @@ class OrganizationUploader(object):
             return
 
         # hack into this to upload NAP DOC
+        if self.doc_old_filename:
+            self.doc_old_filepath = os.path.join(self.storage_path, data_dict.get('name'), self.doc_old_filename)
+
         self.doc_clear = data_dict.pop('clear_upload_doc', None)
         self.doc_file_field = 'upload_doc'
         self.doc_upload_field_storage = data_dict.pop(self.doc_file_field, None)
-        print("#" * 25)
-        print("-" * 25)
-        print(data_dict)
-        print(self.doc_clear)
-        print(self.doc_file_field)
-        print(self.doc_upload_field_storage)
         if isinstance(self.doc_upload_field_storage, (ALLOWED_UPLOAD_TYPES)):
             self.doc_filename = self.doc_upload_field_storage.filename
             self.doc_filename = munge.munge_filename(self.doc_filename)
@@ -114,8 +111,13 @@ class OrganizationUploader(object):
             data_dict['url_type'] = 'upload'
             self.doc_upload_file = _get_underlying_file(self.doc_upload_field_storage)
             self.doc_tmp_filepath = self.doc_filepath + '~'
-        print("-" * 25)
-        print("#" * 25)
+        # keep the file if there has been no change
+        elif self.doc_old_filename and not self.doc_old_filename.startswith('http'):
+            if not self.doc_clear:
+                data_dict['doc_document_upload'] = self.doc_old_filename
+            if self.doc_clear and self.doc_url == self.doc_old_filename:
+                data_dict['doc_document_upload'] = ''
+        # end NAP DOC hack
 
         if self.old_filename:
             self.old_filepath = os.path.join(self.storage_path, data_dict.get('name'), self.old_filename)

--- a/ckanext/scheming/plugins.py
+++ b/ckanext/scheming/plugins.py
@@ -374,29 +374,6 @@ class SchemingOrganizationsPlugin(p.SingletonPlugin, _GroupOrganizationMixin,
     def get_resource_uploader(self, data_dict):
         return None
 
-    # # IOrganizationController
-    # def create(self, entity):
-    #     self._print_entity(entity, "scheming org create")
-    #     return entity
-    #
-    # def edit(self, entity):
-    #     self._print_entity(entity, "scheming org edit")
-    #     return entity
-    #
-    # @staticmethod
-    # def _print_entity(entity, message):
-    #     print("#"*25)
-    #     print("-" * 25)
-    #     print(message)
-    #     print()
-    #     print(entity)
-    #     print(hasattr(entity, "extras"))
-    #     if hasattr(entity, "extras"):
-    #         print(entity.extras)
-    #     print()
-    #     print("-" * 25)
-    #     print("#"*25)
-
 
 class SchemingITranslationPlugin(p.SingletonPlugin, DefaultTranslation):
     p.implements(p.ITranslation)

--- a/ckanext/scheming/plugins.py
+++ b/ckanext/scheming/plugins.py
@@ -376,16 +376,17 @@ class SchemingOrganizationsPlugin(p.SingletonPlugin, _GroupOrganizationMixin,
 
     # IOrganizationController
     def create(self, entity):
-        self._print_entity(entity)
+        self._print_entity(entity, "scheming org create")
         return entity
 
     def edit(self, entity):
-        self._print_entity(entity)
+        self._print_entity(entity, "scheming org edit")
         return entity
 
     @staticmethod
-    def _print_entity(entity):
+    def _print_entity(entity, message):
         print("#"*25)
+        print(message)
         print()
         print(entity)
         print()

--- a/ckanext/scheming/plugins.py
+++ b/ckanext/scheming/plugins.py
@@ -386,12 +386,16 @@ class SchemingOrganizationsPlugin(p.SingletonPlugin, _GroupOrganizationMixin,
     @staticmethod
     def _print_entity(entity, message):
         print("#"*25)
+        print("-" * 25)
         print(message)
         print()
         print(entity)
+        print(hasattr(entity, "extras"))
+        if hasattr(entity, "extras"):
+            print(entity.extras)
         print()
+        print("-" * 25)
         print("#"*25)
-
 
 
 class SchemingITranslationPlugin(p.SingletonPlugin, DefaultTranslation):

--- a/ckanext/scheming/plugins.py
+++ b/ckanext/scheming/plugins.py
@@ -324,6 +324,7 @@ class SchemingOrganizationsPlugin(p.SingletonPlugin, _GroupOrganizationMixin,
     p.implements(p.IActions)
     p.implements(p.IValidators)
     p.implements(p.IUploader)
+    p.implements(p.IOrganizationController)
 
     SCHEMA_OPTION = 'scheming.organization_schemas'
     FALLBACK_OPTION = 'scheming.organization_fallback'
@@ -372,6 +373,24 @@ class SchemingOrganizationsPlugin(p.SingletonPlugin, _GroupOrganizationMixin,
 
     def get_resource_uploader(self, data_dict):
         return None
+
+    # IOrganizationController
+    def create(self, entity):
+        self._print_entity(entity)
+        return entity
+
+    def edit(self, entity):
+        self._print_entity(entity)
+        return entity
+
+    @staticmethod
+    def _print_entity(entity):
+        print("#"*25)
+        print()
+        print(entity)
+        print()
+        print("#"*25)
+
 
 
 class SchemingITranslationPlugin(p.SingletonPlugin, DefaultTranslation):

--- a/ckanext/scheming/plugins.py
+++ b/ckanext/scheming/plugins.py
@@ -374,28 +374,28 @@ class SchemingOrganizationsPlugin(p.SingletonPlugin, _GroupOrganizationMixin,
     def get_resource_uploader(self, data_dict):
         return None
 
-    # IOrganizationController
-    def create(self, entity):
-        self._print_entity(entity, "scheming org create")
-        return entity
-
-    def edit(self, entity):
-        self._print_entity(entity, "scheming org edit")
-        return entity
-
-    @staticmethod
-    def _print_entity(entity, message):
-        print("#"*25)
-        print("-" * 25)
-        print(message)
-        print()
-        print(entity)
-        print(hasattr(entity, "extras"))
-        if hasattr(entity, "extras"):
-            print(entity.extras)
-        print()
-        print("-" * 25)
-        print("#"*25)
+    # # IOrganizationController
+    # def create(self, entity):
+    #     self._print_entity(entity, "scheming org create")
+    #     return entity
+    #
+    # def edit(self, entity):
+    #     self._print_entity(entity, "scheming org edit")
+    #     return entity
+    #
+    # @staticmethod
+    # def _print_entity(entity, message):
+    #     print("#"*25)
+    #     print("-" * 25)
+    #     print(message)
+    #     print()
+    #     print(entity)
+    #     print(hasattr(entity, "extras"))
+    #     if hasattr(entity, "extras"):
+    #         print(entity.extras)
+    #     print()
+    #     print("-" * 25)
+    #     print("#"*25)
 
 
 class SchemingITranslationPlugin(p.SingletonPlugin, DefaultTranslation):

--- a/ckanext/scheming/plugins.py
+++ b/ckanext/scheming/plugins.py
@@ -324,7 +324,7 @@ class SchemingOrganizationsPlugin(p.SingletonPlugin, _GroupOrganizationMixin,
     p.implements(p.IActions)
     p.implements(p.IValidators)
     p.implements(p.IUploader)
-    p.implements(p.IOrganizationController)
+    p.implements(p.IOrganizationController, inherit=True)
 
     SCHEMA_OPTION = 'scheming.organization_schemas'
     FALLBACK_OPTION = 'scheming.organization_fallback'

--- a/ckanext/scheming/templates/scheming/display_snippets/doc_download.html
+++ b/ckanext/scheming/templates/scheming/display_snippets/doc_download.html
@@ -1,0 +1,1 @@
+{{ h.link_to(data[field.field_name], data[field.field_name], rel=field.display_property, target='_blank') }}

--- a/ckanext/scheming/templates/scheming/display_snippets/doc_download.html
+++ b/ckanext/scheming/templates/scheming/display_snippets/doc_download.html
@@ -1,1 +1,1 @@
-<b>TEST</b>{{ h.link_to(data[field.field_name], data[field.field_name], rel=field.display_property, target='_blank') }}
+<b>TEST</b> {{ h.link_to(data[field.field_name], data[field.field_name], rel=field.display_property, target='_blank') }}

--- a/ckanext/scheming/templates/scheming/display_snippets/doc_download.html
+++ b/ckanext/scheming/templates/scheming/display_snippets/doc_download.html
@@ -1,1 +1,1 @@
-{{ h.link_to(data[field.field_name], data[field.field_name], rel=field.display_property, target='_blank') }}
+<b>TEST</b>{{ h.link_to(data[field.field_name], data[field.field_name], rel=field.display_property, target='_blank') }}

--- a/ckanext/scheming/templates/scheming/display_snippets/doc_download.html
+++ b/ckanext/scheming/templates/scheming/display_snippets/doc_download.html
@@ -1,1 +1,0 @@
-<b>TEST</b> {{ h.link_to(data[field.field_name], data[field.field_name], rel=field.display_property, target='_blank') }}

--- a/ckanext/scheming/templates/scheming/form_snippets/doc_upload.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/doc_upload.html
@@ -12,7 +12,7 @@
     is_upload=is_upload,
     upload_label=h.scheming_language_text(field.upload_label),
     url_label=h.scheming_language_text(field.label),
-    placeholder=""
+    placeholder=field.form_placeholder
     )
 }}
 {# image_upload macro doesn't support call #}

--- a/ckanext/scheming/templates/scheming/form_snippets/doc_upload.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/doc_upload.html
@@ -1,0 +1,19 @@
+{% import 'macros/form.html' as form %}
+
+{%- set is_upload = (data.url_type == 'upload') -%}
+{{ form.image_upload(
+    data,
+    errors,
+    field_url=field.field_name,
+    field_upload=field.upload_field,
+    field_clear=field.upload_clear,
+    is_upload_enabled=h.uploads_enabled(),
+    is_url=false,
+    is_upload=is_upload,
+    upload_label=h.scheming_language_text(field.upload_label),
+    url_label=h.scheming_language_text(field.label),
+    placeholder=""
+    )
+}}
+{# image_upload macro doesn't support call #}
+{%- snippet 'scheming/form_snippets/help_text.html', field=field -%}

--- a/ckanext/scheming/templates/scheming/organization/about.html
+++ b/ckanext/scheming/templates/scheming/organization/about.html
@@ -13,7 +13,7 @@
         <dd><a href="mailto:{{ c.group_dict[f.field_name] or ('&nbsp;'|safe) }}">{{ c.group_dict[f.field_name] or ("&nbsp;"|safe) }}</a></dd>
     {% elif f.field_name in ('rtti_doc_document_upload', 'srti_doc_document_upload', 'sstp_doc_document_upload') %}
     <dd>
-        <a href="{{ h.get_site_protocol_and_host()[0} }}://{{ h.get_site_protocol_and_host()[1} }}/uploads/organization/{{ c.group_dict[name] }}/{{ c.group_dict[f.field_name] }}">
+        <a href="{{ h.get_site_protocol_and_host()[0] }}://{{ h.get_site_protocol_and_host()[1] }}/uploads/organization/{{ c.group_dict[name] }}/{{ c.group_dict[f.field_name] }}">
         {{ c.group_dict[f.field_name] or ("&nbsp;"|safe) }}
         </a>
     </dd>

--- a/ckanext/scheming/templates/scheming/organization/about.html
+++ b/ckanext/scheming/templates/scheming/organization/about.html
@@ -12,7 +12,11 @@
     {% elif f.field_name == 'do_email' %}
         <dd><a href="mailto:{{ c.group_dict[f.field_name] or ('&nbsp;'|safe) }}">{{ c.group_dict[f.field_name] or ("&nbsp;"|safe) }}</a></dd>
     {% elif f.field_name in ('rtti_doc_document_upload', 'srti_doc_document_upload', 'sstp_doc_document_upload') %}
-    <dd><a href="{{ ckan.site_url }}/uploads/organization/{{ c.group_dict[name] }}/{{ c.group_dict[f.field_name] }}">{{ c.group_dict[f.field_name] or ("&nbsp;"|safe) }}</a></dd>
+    <dd>
+        <a href="{{ h.get_site_protocol_and_host()[0} }}://{{ h.get_site_protocol_and_host()[1} }}/uploads/organization/{{ c.group_dict[name] }}/{{ c.group_dict[f.field_name] }}">
+        {{ c.group_dict[f.field_name] or ("&nbsp;"|safe) }}
+        </a>
+    </dd>
     {% else %}
         <dd>{{ c.group_dict[f.field_name] or ("&nbsp;"|safe) }}</dd>
     {% endif %}

--- a/ckanext/scheming/templates/scheming/organization/about.html
+++ b/ckanext/scheming/templates/scheming/organization/about.html
@@ -12,7 +12,7 @@
     {% elif f.field_name == 'do_email' %}
         <dd><a href="mailto:{{ c.group_dict[f.field_name] or ('&nbsp;'|safe) }}">{{ c.group_dict[f.field_name] or ("&nbsp;"|safe) }}</a></dd>
     {% elif f.field_name in ('rtti_doc_document_upload', 'srti_doc_document_upload', 'sstp_doc_document_upload') %}
-        <dd><b>TEST</b>{{ c.group_dict[f.field_name] or ("&nbsp;"|safe) }}</dd>
+    <dd><a href="uploads/organization/{{ c.group_dict[title] }}/{{ c.group_dict[f.field_name] }}">{{ c.group_dict[f.field_name] or ("&nbsp;"|safe) }}</a></dd>
     {% else %}
         <dd>{{ c.group_dict[f.field_name] or ("&nbsp;"|safe) }}</dd>
     {% endif %}

--- a/ckanext/scheming/templates/scheming/organization/about.html
+++ b/ckanext/scheming/templates/scheming/organization/about.html
@@ -6,13 +6,15 @@
 <br/>
 <dl>
 {% for f in c.scheming_fields if f.field_name not in ('title','description_translated','name', 'image_url') %}
-    <dt>{{ h.scheming_language_text(f.label) }}:</dt>
     {% if f.field_name == 'do_website' %}
+        <dt>{{ h.scheming_language_text(f.label) }}:</dt>
         <dd><a href="{{ c.group_dict[f.field_name] or ('&nbsp;'|safe) }}" target="_blank">{{ c.group_dict[f.field_name] or ("&nbsp;"|safe) }}</a></dd>
     {% elif f.field_name == 'do_email' %}
+        <dt>{{ h.scheming_language_text(f.label) }}:</dt>
         <dd><a href="mailto:{{ c.group_dict[f.field_name] or ('&nbsp;'|safe) }}">{{ c.group_dict[f.field_name] or ("&nbsp;"|safe) }}</a></dd>
     {% elif f.field_name in ('rtti_doc_document_upload', 'srti_doc_document_upload', 'sstp_doc_document_upload') %}
         {% if h.user_in_org_or_group(c.group_dict['name']) %}
+        <dt>{{ h.scheming_language_text(f.label) }}:</dt>
         <dd>
             <a href="{{ h.get_site_protocol_and_host()[0] }}://{{ h.get_site_protocol_and_host()[1] }}/uploads/organization/{{ c.group_dict['name'] }}/{{ c.group_dict[f.field_name] }}" target="_blank">
             {{ c.group_dict[f.field_name] or ("&nbsp;"|safe) }}
@@ -21,9 +23,11 @@
         {% endif %}
     {% elif f.field_name in ('agreement_declaration_mmtis', 'organization_agreement_declaration') %}
         {% if h.user_in_org_or_group(c.group_dict['name']) %}
+            <dt>{{ h.scheming_language_text(f.label) }}:</dt>
             <dd>{{ c.group_dict[f.field_name] or ("&nbsp;"|safe) }}</dd>
         {% endif %}
     {% else %}
+        <dt>{{ h.scheming_language_text(f.label) }}:</dt>
         <dd>{{ c.group_dict[f.field_name] or ("&nbsp;"|safe) }}</dd>
     {% endif %}
 {% endfor %}

--- a/ckanext/scheming/templates/scheming/organization/about.html
+++ b/ckanext/scheming/templates/scheming/organization/about.html
@@ -2,7 +2,7 @@
 
 {% block primary_content_inner %}
 <h2> {{ c.group_dict['title'] }} </h2>
-<div>c.group_dict</div>
+<div>{{ c.group_dict }}</div>
 <p> {{ h.render_markdown(h.benap_field_translated_fallback(c.group_dict['description_translated'])) }} </p>
 <br/>
 <dl>

--- a/ckanext/scheming/templates/scheming/organization/about.html
+++ b/ckanext/scheming/templates/scheming/organization/about.html
@@ -2,6 +2,7 @@
 
 {% block primary_content_inner %}
 <h2> {{ c.group_dict['title'] }} </h2>
+<div>c.group_dict</div>
 <p> {{ h.render_markdown(h.benap_field_translated_fallback(c.group_dict['description_translated'])) }} </p>
 <br/>
 <dl>

--- a/ckanext/scheming/templates/scheming/organization/about.html
+++ b/ckanext/scheming/templates/scheming/organization/about.html
@@ -16,6 +16,7 @@
         <a href="{{ h.get_site_protocol_and_host()[0] }}://{{ h.get_site_protocol_and_host()[1] }}/uploads/organization/{{ c.group_dict['name'] }}/{{ c.group_dict[f.field_name] }}" target="_blank">
         {{ c.group_dict[f.field_name] or ("&nbsp;"|safe) }}
         </a>
+        <p>{{ h.organizations_available(permission='manage_group') }}</p>
     </dd>
     {% else %}
         <dd>{{ c.group_dict[f.field_name] or ("&nbsp;"|safe) }}</dd>

--- a/ckanext/scheming/templates/scheming/organization/about.html
+++ b/ckanext/scheming/templates/scheming/organization/about.html
@@ -11,6 +11,8 @@
         <dd><a href="{{ c.group_dict[f.field_name] or ('&nbsp;'|safe) }}" target="_blank">{{ c.group_dict[f.field_name] or ("&nbsp;"|safe) }}</a></dd>
     {% elif f.field_name == 'do_email' %}
         <dd><a href="mailto:{{ c.group_dict[f.field_name] or ('&nbsp;'|safe) }}">{{ c.group_dict[f.field_name] or ("&nbsp;"|safe) }}</a></dd>
+    {% elif f.field_name in ('rtti_doc_document_upload', 'srti_doc_document_upload', 'sstp_doc_document_upload') %}
+        <dd><b>TEST</b>{{ c.group_dict[f.field_name] or ("&nbsp;"|safe) }}</dd>
     {% else %}
         <dd>{{ c.group_dict[f.field_name] or ("&nbsp;"|safe) }}</dd>
     {% endif %}

--- a/ckanext/scheming/templates/scheming/organization/about.html
+++ b/ckanext/scheming/templates/scheming/organization/about.html
@@ -16,7 +16,7 @@
         <a href="{{ h.get_site_protocol_and_host()[0] }}://{{ h.get_site_protocol_and_host()[1] }}/uploads/organization/{{ c.group_dict['name'] }}/{{ c.group_dict[f.field_name] }}" target="_blank">
         {{ c.group_dict[f.field_name] or ("&nbsp;"|safe) }}
         </a>
-        <p>{{ h.organizations_available(permission='manage_group') }}</p>
+        <p>{{ h.user_in_org_or_group() }}</p>
     </dd>
     {% else %}
         <dd>{{ c.group_dict[f.field_name] or ("&nbsp;"|safe) }}</dd>

--- a/ckanext/scheming/templates/scheming/organization/about.html
+++ b/ckanext/scheming/templates/scheming/organization/about.html
@@ -2,7 +2,6 @@
 
 {% block primary_content_inner %}
 <h2> {{ c.group_dict['title'] }} </h2>
-<div>{{ c.group_dict }}</div>
 <p> {{ h.render_markdown(h.benap_field_translated_fallback(c.group_dict['description_translated'])) }} </p>
 <br/>
 <dl>
@@ -13,7 +12,7 @@
     {% elif f.field_name == 'do_email' %}
         <dd><a href="mailto:{{ c.group_dict[f.field_name] or ('&nbsp;'|safe) }}">{{ c.group_dict[f.field_name] or ("&nbsp;"|safe) }}</a></dd>
     {% elif f.field_name in ('rtti_doc_document_upload', 'srti_doc_document_upload', 'sstp_doc_document_upload') %}
-    <dd><a href="uploads/organization/{{ c.group_dict[title] }}/{{ c.group_dict[f.field_name] }}">{{ c.group_dict[f.field_name] or ("&nbsp;"|safe) }}</a></dd>
+    <dd><a href="{{ ckan.site_url }}/uploads/organization/{{ c.group_dict[name] }}/{{ c.group_dict[f.field_name] }}">{{ c.group_dict[f.field_name] or ("&nbsp;"|safe) }}</a></dd>
     {% else %}
         <dd>{{ c.group_dict[f.field_name] or ("&nbsp;"|safe) }}</dd>
     {% endif %}

--- a/ckanext/scheming/templates/scheming/organization/about.html
+++ b/ckanext/scheming/templates/scheming/organization/about.html
@@ -13,7 +13,7 @@
         <dd><a href="mailto:{{ c.group_dict[f.field_name] or ('&nbsp;'|safe) }}">{{ c.group_dict[f.field_name] or ("&nbsp;"|safe) }}</a></dd>
     {% elif f.field_name in ('rtti_doc_document_upload', 'srti_doc_document_upload', 'sstp_doc_document_upload') %}
     <dd>
-        <a href="{{ h.get_site_protocol_and_host()[0] }}://{{ h.get_site_protocol_and_host()[1] }}/uploads/organization/{{ c.group_dict[name] }}/{{ c.group_dict[f.field_name] }}">
+        <a href="{{ h.get_site_protocol_and_host()[0] }}://{{ h.get_site_protocol_and_host()[1] }}/uploads/organization/{{ c.group_dict['name'] }}/{{ c.group_dict[f.field_name] }}" target="_blank">
         {{ c.group_dict[f.field_name] or ("&nbsp;"|safe) }}
         </a>
     </dd>

--- a/ckanext/scheming/templates/scheming/organization/about.html
+++ b/ckanext/scheming/templates/scheming/organization/about.html
@@ -12,12 +12,17 @@
     {% elif f.field_name == 'do_email' %}
         <dd><a href="mailto:{{ c.group_dict[f.field_name] or ('&nbsp;'|safe) }}">{{ c.group_dict[f.field_name] or ("&nbsp;"|safe) }}</a></dd>
     {% elif f.field_name in ('rtti_doc_document_upload', 'srti_doc_document_upload', 'sstp_doc_document_upload') %}
-    <dd>
-        <a href="{{ h.get_site_protocol_and_host()[0] }}://{{ h.get_site_protocol_and_host()[1] }}/uploads/organization/{{ c.group_dict['name'] }}/{{ c.group_dict[f.field_name] }}" target="_blank">
-        {{ c.group_dict[f.field_name] or ("&nbsp;"|safe) }}
-        </a>
-        <p>{{ h.user_in_org_or_group(c.group_dict['name']) }}</p>
-    </dd>
+        {% if h.user_in_org_or_group(c.group_dict['name']) %}
+        <dd>
+            <a href="{{ h.get_site_protocol_and_host()[0] }}://{{ h.get_site_protocol_and_host()[1] }}/uploads/organization/{{ c.group_dict['name'] }}/{{ c.group_dict[f.field_name] }}" target="_blank">
+            {{ c.group_dict[f.field_name] or ("&nbsp;"|safe) }}
+            </a>
+        </dd>
+        {% endif %}
+    {% elif f.field_name in ('agreement_declaration_mmtis', 'organization_agreement_declaration') %}
+        {% if h.user_in_org_or_group(c.group_dict['name']) %}
+            <dd>{{ c.group_dict[f.field_name] or ("&nbsp;"|safe) }}</dd>
+        {% endif %}
     {% else %}
         <dd>{{ c.group_dict[f.field_name] or ("&nbsp;"|safe) }}</dd>
     {% endif %}

--- a/ckanext/scheming/templates/scheming/organization/about.html
+++ b/ckanext/scheming/templates/scheming/organization/about.html
@@ -16,7 +16,7 @@
         <a href="{{ h.get_site_protocol_and_host()[0] }}://{{ h.get_site_protocol_and_host()[1] }}/uploads/organization/{{ c.group_dict['name'] }}/{{ c.group_dict[f.field_name] }}" target="_blank">
         {{ c.group_dict[f.field_name] or ("&nbsp;"|safe) }}
         </a>
-        <p>{{ h.user_in_org_or_group() }}</p>
+        <p>{{ h.user_in_org_or_group(c.group_dict['name']) }}</p>
     </dd>
     {% else %}
         <dd>{{ c.group_dict[f.field_name] or ("&nbsp;"|safe) }}</dd>


### PR DESCRIPTION
PDF uploads and downloads. For admins and logged in users

Bij het overzicht van de organisatie zou een lid van de organisatie een aantal pdf’s moeten kunnen opladen (ingevulde templates). Dit hoeft niet percé in de metadata, maar dus enkel zichtbaar voor leden van die organisatie. Een lid van de organisatie moet deze nadien opnieuw kunnen downloaden om te bekijken en dan eventueel opnieuw een aangepaste versie op te laden (overschrijven van de vorige versie). Deze pdfs mogen zeker niet zichtbaar zijn voor andere gebruikers en mogen niet terecht komen in de DCAT-stream.