### PR TITLE
mmtis signed fix

### DIFF
--- a/ckanext/scheming/templates/scheming/organization/about.html
+++ b/ckanext/scheming/templates/scheming/organization/about.html
@@ -27,7 +27,7 @@
     {% elif f.field_name in ('agreement_declaration_mmtis', 'organization_agreement_declaration_nap', 'optional_comment') %}
         {% if h.check_access('organization_update', {'id': c.group_dict.id}) %}
             <dt>{{ h.scheming_language_text(f.label) }}:</dt>
-            <dd>{{ _('Signed') if c.group_dict[f.field_name] else ("&nbsp;"|safe) }}</dd>
+            <dd>{{ _('Signed') if c.group_dict[f.field_name] == ["Y"] else ("&nbsp;"|safe) }}</dd>
         {% endif %}
     {% else %}
         <dt>{{ h.scheming_language_text(f.label) }}:</dt>


### PR DESCRIPTION
This request updates the metadata field 'agreement_declaration_mmtis'. If this value is not signed, it is set to ["N"]. The code has been modified to ensure that a value of ["N"] does not display as "Signed" in the frontend. So only a value of ["Y"] shows signed in the frontend.