### PR TITLE
card 441 - bug fix when there is no desciption for a dataset

### DIFF
--- a/ckanext/scheming/templates/scheming/package/read.html
+++ b/ckanext/scheming/templates/scheming/package/read.html
@@ -3,10 +3,12 @@
 {%- set schema = h.scheming_get_dataset_schema(dataset_type) -%}
 
 {% block package_notes %}
-    <p>
-        {{ h.render_markdown(h.scheming_language_text(pkg['notes_translated']) or
-        h.benap_scheming_language_text_fallback(pkg['notes_translated'], pkg['language'])) }}
-    </p>
+    {% if pkg['notes_translated'] %}
+        <p>
+            {{ h.render_markdown(h.scheming_language_text(pkg['notes_translated']) or
+            h.benap_scheming_language_text_fallback(pkg['notes_translated'], pkg['language'])) }}
+        </p>
+    {% endif %}
   {%- if not dataset_type -%}
     <p>
     {{ _('dataset_type not passed to template. your version of CKAN


### PR DESCRIPTION
Deze pr is een bug fix wanneer een dataset geen beschrijving heeft. Dit gaf een internal server error maar is nu opeglost.