### PR TITLE
card 9 - create hidden form snippet for dataset theme

### DIFF
--- a/ckanext/scheming/presets.json
+++ b/ckanext/scheming/presets.json
@@ -146,6 +146,14 @@
         "form_snippet": "json.html",
         "display_snippet": "json.html"
       }
+    },
+    {
+      "preset_name": "hidden",
+      "values": {
+        "form_snippet": "hidden.html",
+        "display_snippet": "select.html",
+        "validators": "scheming_choices"
+      }
     }
 
   ]

--- a/ckanext/scheming/templates/scheming/form_snippets/hidden.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/hidden.html
@@ -1,0 +1,6 @@
+{% import 'macros/form.html' as form %}
+
+{%- set default_value = "http://publications.europa.eu/resource/authority/data-theme/TRAN" -%}
+{%- set theme_value = data[field.field_name] | default(default_value) -%}
+
+<input type="hidden" name="{{ field.field_name }}" value="{{ theme_value }}" />


### PR DESCRIPTION
Deze pr voegt een nieuwe form snippet toe genaamd 'hidden' die een default waarde meegeeft aan een veld en het veld tevens verbergt in de frontend.